### PR TITLE
[PHP] Allow to specify ini templates for PECL exts

### DIFF
--- a/isoft.php/README.md
+++ b/isoft.php/README.md
@@ -2,7 +2,7 @@ Intellectsoft PHP Ansible role
 =================================
 
 Handles installation of php-fpm and php-cli. Will also install listed php and pecl extensions.
- 
+
 ## Installed extensions
 There is set of mandatory extensions:
 
@@ -14,7 +14,32 @@ There is set of mandatory extensions:
 - php5-curl
 ```
 
-If you need some other extensions, just set list of it into `php_extensions` var. Also you have `pecl_extensions` list.
+If you need some other extensions, just set list of it into `php_extensions` var. Also you have `pecl_extensions` list of hashes.
+
+### PECL extensions
+
+You can specify ini file template for PECL extension via `ini` property:
+
+```
+pecl_extensions:
+ - name: xdebug
+   ini: templates/php/xdebug.ini.j2
+```
+
+Also you can extend default PECL extension ini:
+
+```
+{% extends 'roles/isoft.php/templates/extension.ini.j2' %}
+
+{% block extension_settings %}
+[debug]
+; Remote settings
+xdebug.remote_enable=1
+xdebug.remote_autostart=1
+{% endblock %}
+```
+
+Please note that `ini` property is optional.
 
 ## Dependency
 On Debian depends from `isoft.dotdeb`

--- a/isoft.php/tasks/pecl.yml
+++ b/isoft.php/tasks/pecl.yml
@@ -6,7 +6,7 @@
   tags: [packages,php]
 
 - name: Install PECL extensions
-  shell: echo "\n\n\n\n\n\n\n\n\n\n" | pecl install {{ item }}
+  shell: echo "\n\n\n\n\n\n\n\n\n\n" | pecl install {{ item.name }}
   register: pecl_result
   changed_when: "'already installed' not in pecl_result.stdout"
   failed_when: "pecl_result.stderr or ('ERROR' in pecl_result.stdout)"
@@ -14,7 +14,7 @@
   tags: [packages,php]
 
 - name: Create PECL extensions .ini files
-  template: src=extension.ini.j2 dest=/etc/php5/mods-available/{{ item }}.ini owner=root group=root mode=0644
+  template: src={{ item.ini | default("extension.ini.j2") }} dest=/etc/php5/mods-available/{{ item.name }}.ini owner=root group=root mode=0644
   with_items: php_pecl_extensions
   when: ansible_os_family == "Debian"
   tags: [packages,php]

--- a/isoft.php/templates/extension.ini.j2
+++ b/isoft.php/templates/extension.ini.j2
@@ -1,4 +1,6 @@
 ; {{ ansible_managed }}
-; configuration for php PECL {{ item }} extension
+; configuration for php PECL {{ item.name }} extension
 ; priority=20
-extension={{ item }}.so
+extension={{ item.name }}.so
+
+{% block extension_settings %}{% endblock %}

--- a/isoft.php/templates/extension.ini.j2
+++ b/isoft.php/templates/extension.ini.j2
@@ -1,6 +1,6 @@
 ; {{ ansible_managed }}
 ; configuration for php PECL {{ item.name }} extension
 ; priority=20
-extension={{ item.name }}.so
+zend_extension={{ item.name }}.so
 
 {% block extension_settings %}{% endblock %}


### PR DESCRIPTION
You can specify ini file template for PECL extension via `ini` property:

```
pecl_extensions:
 - name: xdebug
   ini: templates/php/xdebug.ini.j2
```

Also you can extend default PECL extension ini:

```
{% extends 'roles/isoft.php/templates/extension.ini.j2' %}

{% block extension_settings %}
[debug]
; Remote settings
xdebug.remote_enable=1
xdebug.remote_autostart=1
{% endblock %}
```

Please note that `ini` property is optional.