### PR TITLE
Remove deprecated option explicit_defaults_for_timestamp.

### DIFF
--- a/isoft.mysql/templates/my.cnf.j2
+++ b/isoft.mysql/templates/my.cnf.j2
@@ -41,7 +41,7 @@ datadir		= /var/lib/mysql
 tmpdir		= /tmp
 lc-messages-dir	= /usr/share/mysql
 skip-external-locking
-explicit_defaults_for_timestamp
+
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.


### PR DESCRIPTION
Remove deprecated option explicit_defaults_for_timestamp.

http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp
